### PR TITLE
Add GitHub workflow to check bundle integrity

### DIFF
--- a/.github/.psh.yaml.override
+++ b/.github/.psh.yaml.override
@@ -1,0 +1,7 @@
+const:
+    APP_URL: "http://localhost:8000"
+    DB_HOST: "mysql"
+    DB_USER: "root"
+    DB_PASSWORD: "root"
+    SHOPWARE_ES_HOSTS: "elasticsearch:9200"
+    APP_MAILER_URL: "null://localhost"

--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -1,0 +1,38 @@
+name: 'Set up Workspace'
+description: 'Initialize Shopware and install Blurhash Plugin'
+runs:
+  using: "composite"
+  steps:
+    - id: checkout_shopware
+      name: Checkout Shopware Development Template
+      uses: actions/checkout@v2
+      with:
+        repository: shopware/development
+        path: shopware
+    - id: after_shopware_checkout
+      name: After Checkout Shopware
+      shell: bash
+      run: |
+        ln -s $(pwd)/sw-blurhash shopware/custom/plugins/sw-blurhash
+        cp sw-blurhash/.github/.psh.yaml.override shopware/.psh.yaml.override
+    - id: install_shopware
+      name: Install Shopware
+      shell: bash
+      working-directory: shopware
+      run: |
+        ./psh.phar init
+    - id: prepare_bundles
+      name: Prepare bundles
+      shell: bash
+      working-directory: shopware
+      run: |
+        ./psh.phar storefront:install-dependencies
+        ./psh.phar storefront:build
+    - id: install_plugin
+      name: Install Blurhash Plugin
+      shell: bash
+      working-directory: shopware
+      run: |
+        composer dump-autoload --dev -d ./custom/plugins/sw-blurhash
+        php ./bin/console plugin:refresh
+        php ./bin/console plugin:install EcBlurHash --activate

--- a/.github/workflows/bundle-integrity.yml
+++ b/.github/workflows/bundle-integrity.yml
@@ -1,0 +1,46 @@
+name: Test and Integrity Check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  integrity:
+    name: Check Bundle Integrity
+    runs-on: ubuntu-latest
+    container: shopware/development:7.4-composer-2
+    env:
+      APP_ENV: test
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: root
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: sw-blurhash
+      - name: Set up Workspace
+        uses: ./sw-blurhash/.github/actions/setup-workspace
+      - name: Rebuild Administration and Storefront Bundle
+        shell: bash
+        working-directory: shopware
+        run: |
+          ./psh.phar storefront:build
+          ./psh.phar administration:build
+      - name: Rollup and transpile Blurhash chunks
+        shell: bash
+        working-directory: sw-blurhash
+        run: |
+          ./bin/build-blurhash.sh
+      - name: Check Bundle Integrity
+        shell: bash
+        working-directory: sw-blurhash
+        run: |
+          echo "Following files differs from those commited:"
+          git --no-pager diff --name-only --exit-code HEAD


### PR DESCRIPTION
A workflow that checks the integrity of storefront and administration bundle and the additional Rolluped and transpiled Blurhash assets.

Introduces the Initial folder structure for github's "actions".

Furthermore, the workspace setup is provided as a separate action. This way
 it can be reused within the project. Unfortunately, certain
 steps must be taken for all workflows that may use this action:

- Checkout of the repository must take place before the use of
 this action
- The checkout of the repository must be made into the sub-folder
 `sw-blurhash` (with path: sw-blurhash)
- The action can be used by
 `uses: ./sw-blurhash/.github/actions/setup-workspace`
- Mysql database service must have the name "mysql"
 and the root password must be "root"